### PR TITLE
feat: add payment support to create_expense

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ See [TOOLS.md](TOOLS.md) for detailed documentation.
 - `get-user`: Get information about a specific user
 
 ### Expense Tools
-- `create-expense`: Create a new expense with splits
+- `create-expense`: Create a new expense with splits, including cash payments (`payment=True`)
 - `get-expenses`: List expenses with optional filters
 - `get-expense`: Get detailed expense information
 - `update-expense`: Update an existing expense
 - `delete-expense`: Delete an expense
+- `restore-expense`: Restore a deleted expense
 
 ### Group Tools
 - `get-groups`: List all groups

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -124,6 +124,7 @@ Create a new expense in Splitwise.
 | `category_id` | integer | No | null | Category ID from get-categories |
 | `users` | array | No | null | List of user split information |
 | `split_equally` | boolean | No | true | Whether to split equally among users |
+| `payment` | boolean | No | false | Set to true for cash settlement/payment records |
 
 **User Split Format:**
 ```json
@@ -324,6 +325,32 @@ Delete an expense permanently.
 **Errors:**
 - `404`: Expense not found
 - `403`: Insufficient permissions
+
+---
+
+### restore-expense
+
+Restore a previously deleted expense.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `expense_id` | integer | Yes | The ID of the expense to restore |
+
+**Returns:**
+```json
+{
+  "success": true
+}
+```
+
+**Example Usage:**
+```
+"Restore expense 987654"
+```
+
+**Errors:**
+- `404`: Expense not found
 
 ---
 

--- a/src/splitwise_mcp_server/server.py
+++ b/src/splitwise_mcp_server/server.py
@@ -172,12 +172,14 @@ def register_expense_tools(mcp: FastMCP) -> None:
         details: Optional[str] = None,
         repeat_interval: Optional[str] = None,
         users: Optional[List[Dict[str, Any]]] = None,
-        split_equally: bool = True
+        split_equally: bool = True,
+        payment: bool = False,
     ) -> Dict[str, Any]:
         """Create a new expense. Cost is a string with 2 decimals (e.g. "25.50").
         Splits equally by default; provide users list with paid_share/owed_share for custom splits.
         Each user needs user_id or (email + first_name + last_name).
         Set repeat_interval to "weekly", "fortnightly", "monthly", or "yearly" for recurring expenses.
+        Set payment=True to create a cash settlement/payment record between users.
         """
         try:
             validate_required(cost, "cost")
@@ -229,6 +231,9 @@ def register_expense_tools(mcp: FastMCP) -> None:
                 expense_data["details"] = details
             if repeat_interval is not None:
                 expense_data["repeat_interval"] = repeat_interval
+            if payment:
+                expense_data["payment"] = True
+                expense_data["creation_method"] = "payment"
 
             result = await client.create_expense(expense_data)
             logger.info(f"Created expense: {description} (${cost})")


### PR DESCRIPTION
Adds `payment` boolean parameter to `create_expense` tool.

## Problem
The `create_expense` tool cannot create proper cash settlement/payment records. API-created payments lack the `payment=true` and `creation_method="payment"` flags, so they appear as regular expenses in the Splitwise UI instead of proper payment transactions.

## Solution
When `payment=True` is passed to `create_expense`, the server now sets `payment=true` and `creation_method="payment"` in the Splitwise API request, matching what the native Splitwise app produces for settlement records.

## Usage
```python
create_expense(
    cost="1612.37",
    description="Payment",
    group_id=100052914,
    payment=True,
    users=[
        {"user_id": 518014, "paid_share": "1612.37", "owed_share": "0.00"},
        {"user_id": 104832672, "paid_share": "0.00", "owed_share": "1612.37"}
    ]
)
```