### PR TITLE
feat: add parse_sentence, update_user, restore_group

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ A Model Context Protocol (MCP) server for [Splitwise](https://www.splitwise.com/
 
 ## Features
 
-- **Full API Access**: Manage expenses, groups, friends, and comments.
+- **Full API Access**: Manage expenses, groups, friends, comments, and payments.
 - **Natural Language Resolution**: Fuzzy matching for names ("John" -> "John Smith") and groups.
+- **Natural Language Expense Creation**: Parse sentences like "I paid R25 for pizza with John" directly into expenses.
 - **Dual Auth**: Supports both OAuth 2.0 (recommended) and API Keys.
 - **Smart Caching**: Optimizes performance for static data like categories and currencies.
 
@@ -16,8 +17,8 @@ A Model Context Protocol (MCP) server for [Splitwise](https://www.splitwise.com/
 pip install splitwise-mcp-server
 
 # From Source
-git clone https://github.com/tarunn2799/splitwise-mcp-server
-cd splitwise-mcp-server
+git clone https://github.com/tarunn2799/splitwise-mcp
+cd splitwise-mcp
 pip install -e .
 ```
 
@@ -40,6 +41,8 @@ Use the keys provided there, and add all three to your `mcp.json`:
       "command": "python",
       "args": ["-m", "splitwise_mcp_server"],
       "env": {
+        "SPLITWISE_OAUTH_CONSUMER_KEY": "your_key_here",
+        "SPLITWISE_OAUTH_CONSUMER_SECRET": "your_secret_here",
         "SPLITWISE_OAUTH_ACCESS_TOKEN": "your_token_here"
       }
     }
@@ -65,9 +68,10 @@ The server enables natural language interactions with your Splitwise data.
 **Examples:**
 - "What's my current balance?"
 - "Split a $50 dinner with Sarah."
-- "Use the receipt I uploaded to split the dinner between Manav and me."
+- "I paid R25 for pizza with John and Francois"
 - "Show me expenses from last month."
 - "Create a group called 'Ski Trip' with Mike."
+- "Log a cash payment from Adre to the group"
 
 ## Tools
 
@@ -76,25 +80,30 @@ See [TOOLS.md](TOOLS.md) for detailed documentation.
 ### User Tools
 - `get-current-user`: Get authenticated user information
 - `get-user`: Get information about a specific user
+- `update-user`: Update a user's profile (name, email)
 
 ### Expense Tools
-- `create-expense`: Create a new expense with splits
+- `create-expense`: Create a new expense with splits, including cash payments (`payment=True`)
 - `get-expenses`: List expenses with optional filters
 - `get-expense`: Get detailed expense information
 - `update-expense`: Update an existing expense
 - `delete-expense`: Delete an expense
+- `restore-expense`: Restore a deleted expense
 
 ### Group Tools
 - `get-groups`: List all groups
 - `get-group`: Get detailed group information
 - `create-group`: Create a new group
 - `delete-group`: Delete a group
+- `restore-group`: Restore a deleted group
 - `add-user-to-group`: Add a user to a group
 - `remove-user-from-group`: Remove a user from a group
 
 ### Friend Tools
 - `get-friends`: List all friends
 - `get-friend`: Get detailed friend information
+- `create-friend`: Add a new friend
+- `delete-friend`: Remove a friendship
 
 ### Resolution Tools
 - `resolve-friend`: Fuzzy match friend names to user IDs
@@ -106,23 +115,20 @@ See [TOOLS.md](TOOLS.md) for detailed documentation.
 - `get-comments`: Get all comments for an expense
 - `delete-comment`: Delete a comment
 
+### Notification Tools
+- `get-notifications`: Get recent notifications
+
 ### Utility Tools
+- `parse-sentence`: Parse natural language into an expense
 - `get-categories`: Get all expense categories
 - `get-currencies`: Get all supported currencies
-
-### Arithmetic Tools
-- `add`: Add multiple numbers
-- `subtract`: Subtract numbers
-- `multiply`: Multiply numbers
-- `divide`: Divide numbers
-- `modulo`: Calculate remainder
 
 ## Development
 
 ```bash
 # Setup
-git clone https://github.com/tarunn2799/splitwise-mcp-server
-cd splitwise-mcp-server
+git clone https://github.com/tarunn2799/splitwise-mcp
+cd splitwise-mcp
 python -m venv venv
 source venv/bin/activate
 pip install -e ".[dev]"

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -2,18 +2,6 @@
 
 This document provides comprehensive documentation for all MCP tools provided by the Splitwise MCP Server.
 
-## Important: Using Arithmetic Tools
-
-**When performing any expense calculations, you MUST use the [Arithmetic Tools](#arithmetic-tools) to ensure accuracy:**
-
-- **Adding amounts**: Use `add` to sum line items, calculate totals with tax/tip
-- **Subtracting amounts**: Use `subtract` for discounts, change, or adjustments
-- **Multiplying amounts**: Use `multiply` for quantities, tax rates, or scaling
-- **Dividing amounts**: Use `divide` to split bills, calculate per-person costs
-- **Checking remainders**: Use `modulo` to verify even splits or calculate remainders
-
-These tools handle proper rounding and decimal precision, preventing floating-point errors that could lead to incorrect expense amounts. Always verify the splits with the total amount to see if it adds up. 
-
 ## Table of Contents
 
 - [User Tools](#user-tools)
@@ -22,8 +10,8 @@ These tools handle proper rounding and decimal precision, preventing floating-po
 - [Friend Tools](#friend-tools)
 - [Resolution Tools](#resolution-tools)
 - [Comment Tools](#comment-tools)
+- [Notification Tools](#notification-tools)
 - [Utility Tools](#utility-tools)
-- [Arithmetic Tools](#arithmetic-tools)
 - [Error Codes](#error-codes)
 - [Common Patterns](#common-patterns)
 
@@ -105,13 +93,46 @@ Get information about a specific user by ID.
 
 ---
 
+### update-user
+
+Update a user's profile information.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `user_id` | integer | Yes | The ID of the user to update |
+| `first_name` | string | No | New first name |
+| `last_name` | string | No | New last name |
+| `email` | string | No | New email address |
+
+**Returns:**
+```json
+{
+  "user": {
+    "id": 67890,
+    "first_name": "Jane",
+    "last_name": "Updated",
+    "email": "jane.new@example.com"
+  }
+}
+```
+
+**Example Usage:**
+```
+"Update user 518014's last name to Greeff"
+```
+
+**Errors:**
+- `404`: User not found
+- `401`: Authentication failed
+
+---
+
 ## Expense Tools
 
 ### create-expense
 
 Create a new expense in Splitwise.
-
-**IMPORTANT:** When creating expenses that involve calculations (tips, splits, percentages, currency conversion), you should use the [Arithmetic Tools](#arithmetic-tools) first to ensure accurate calculations with proper rounding, then use the calculated values in this tool.
 
 **Parameters:**
 | Name | Type | Required | Default | Description |
@@ -122,8 +143,11 @@ Create a new expense in Splitwise.
 | `currency_code` | string | No | "USD" | Three-letter currency code |
 | `date` | string | No | current | ISO 8601 datetime string |
 | `category_id` | integer | No | null | Category ID from get-categories |
+| `details` | string | No | null | Additional notes or details |
+| `repeat_interval` | string | No | null | "weekly", "fortnightly", "monthly", or "yearly" |
 | `users` | array | No | null | List of user split information |
 | `split_equally` | boolean | No | true | Whether to split equally among users |
+| `payment` | boolean | No | false | Set to true for cash settlement/payment records |
 
 **User Split Format:**
 ```json
@@ -327,6 +351,32 @@ Delete an expense permanently.
 
 ---
 
+### restore-expense
+
+Restore a previously deleted expense.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `expense_id` | integer | Yes | The ID of the expense to restore |
+
+**Returns:**
+```json
+{
+  "success": true
+}
+```
+
+**Example Usage:**
+```
+"Restore expense 987654"
+```
+
+**Errors:**
+- `404`: Expense not found
+
+---
+
 ## Group Tools
 
 ### get-groups
@@ -471,6 +521,32 @@ Delete a group permanently.
 
 ---
 
+### restore-group
+
+Restore a previously deleted group.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `group_id` | integer | Yes | The ID of the group to restore |
+
+**Returns:**
+```json
+{
+  "success": true
+}
+```
+
+**Example Usage:**
+```
+"Restore my deleted Roommates group"
+```
+
+**Errors:**
+- `404`: Group not found
+
+---
+
 ### add-user-to-group
 
 Add a user to a group.
@@ -601,6 +677,66 @@ Get detailed information about a specific friend.
 **Example Usage:**
 ```
 "Show me details for my friend Jane"
+```
+
+**Errors:**
+- `404`: Friend not found
+
+---
+
+### create-friend
+
+Add a new friend by email address.
+
+**Parameters:**
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `user_email` | string | Yes | - | Email address of the friend |
+| `user_first_name` | string | No | "" | First name of the friend |
+| `user_last_name` | string | No | "" | Last name of the friend |
+
+**Returns:**
+```json
+{
+  "friend": {
+    "id": 67890,
+    "first_name": "Jane",
+    "last_name": "Smith",
+    "email": "jane@example.com"
+  }
+}
+```
+
+**Example Usage:**
+```
+"Add jane@example.com as a friend"
+```
+
+**Errors:**
+- `400`: Invalid email
+- `404`: User not found on Splitwise
+
+---
+
+### delete-friend
+
+Remove a friendship by friend ID.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `friend_id` | integer | Yes | The ID of the friend to remove |
+
+**Returns:**
+```json
+{
+  "success": true
+}
+```
+
+**Example Usage:**
+```
+"Remove friend 67890"
 ```
 
 **Errors:**
@@ -810,7 +946,70 @@ Delete a comment permanently.
 
 ---
 
+## Notification Tools
+
+### get-notifications
+
+Get recent notifications for the current user.
+
+**Parameters:** None
+
+**Returns:**
+```json
+{
+  "notifications": [
+    {
+      "id": 123,
+      "type": "expense",
+      "content": "John added 'Dinner' for $45.00",
+      "created_at": "2024-01-15T19:30:00Z"
+    }
+  ]
+}
+```
+
+**Example Usage:**
+```
+"Show me my recent Splitwise notifications"
+```
+
+---
+
 ## Utility Tools
+
+### parse-sentence
+
+Parse natural language into an expense. Use `autosave=True` to create immediately, or `False` (default) to preview first.
+
+**Parameters:**
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `input_str` | string | Yes | - | Natural language (e.g., "I paid R25 for pizza with John") |
+| `group_id` | integer | No | 0 | Group ID (0 for non-group) |
+| `friend_id` | integer | No | 0 | Friend user ID (0 for no friend) |
+| `autosave` | boolean | No | false | Auto-create expense (default: preview only) |
+
+**Returns:**
+```json
+{
+  "expense": {
+    "description": "pizza",
+    "cost": "25.00",
+    "currency_code": "ZAR",
+    "users": [...]
+  }
+}
+```
+
+**Example Usage:**
+```
+"Parse 'I paid R200 for dinner with Elsje and Francois' in group 100052914"
+```
+
+**Errors:**
+- `400`: Input cannot be parsed
+
+---
 
 ### get-categories
 
@@ -886,94 +1085,6 @@ Get all supported currency codes.
 ```
 
 **Note:** This data is cached for 24 hours to minimize API calls.
-
----
-
-## Arithmetic Tools
-
-Basic arithmetic operations for reliable expense calculations. These tools handle multiple inputs and proper decimal rounding.
-
-### add
-
-Add multiple numbers together.
-
-**Parameters:**
-- `numbers`: array[float] - List of numbers to add (minimum 1)
-- `decimal_places`: integer - Decimal places to round to (default: 2)
-
-**Returns:** `{ result, result_formatted, operands, operation }`
-
-**Examples:**
-- Add line items: `add([12.50, 8.75, 15.00])` → 36.25
-- Total with tax/tip: `add([85.00, 7.65, 15.30])` → 107.95
-
----
-
-### subtract
-
-Subtract numbers sequentially (left to right).
-
-**Parameters:**
-- `numbers`: array[float] - List of numbers to subtract (minimum 2)
-- `decimal_places`: integer - Decimal places to round to (default: 2)
-
-**Returns:** `{ result, result_formatted, operands, operation }`
-
-**Examples:**
-- Calculate change: `subtract([100.00, 87.50])` → 12.50
-- Apply discount: `subtract([50.00, 5.00])` → 45.00
-- Multiple deductions: `subtract([100.00, 10.00, 5.00, 2.50])` → 82.50
-
----
-
-### multiply
-
-Multiply multiple numbers together.
-
-**Parameters:**
-- `numbers`: array[float] - List of numbers to multiply (minimum 2)
-- `decimal_places`: integer - Decimal places to round to (default: 2)
-
-**Returns:** `{ result, result_formatted, operands, operation }`
-
-**Examples:**
-- Item total: `multiply([12.50, 3])` → 37.50 (price × quantity)
-- Apply tax: `multiply([100.00, 1.08])` → 108.00 (8% tax)
-- Tax + tip: `multiply([10.00, 1.08, 1.15])` → 12.42
-
----
-
-### divide
-
-Divide numbers sequentially (left to right).
-
-**Parameters:**
-- `numbers`: array[float] - List of numbers to divide (minimum 2)
-- `decimal_places`: integer - Decimal places to round to (default: 2)
-
-**Returns:** `{ result, result_formatted, operands, operation }`
-
-**Examples:**
-- Split bill: `divide([120.00, 4])` → 30.00 (total / people)
-- Unit price: `divide([45.00, 3])` → 15.00 (total / quantity)
-- Multiple divisions: `divide([100.00, 2, 5])` → 10.00
-
----
-
-### modulo
-
-Calculate remainder of division.
-
-**Parameters:**
-- `a`: float - Dividend
-- `b`: float - Divisor
-- `decimal_places`: integer - Decimal places to round to (default: 2)
-
-**Returns:** `{ result, result_formatted, operands, operation }`
-
-**Examples:**
-- Check remainder: `modulo(100.00, 3)` → 1.00
-- Verify even split: `modulo(120.00, 4)` → 0.00 (divides evenly)
 
 ---
 
@@ -1131,29 +1242,15 @@ All tools may return the following error types:
    → Returns matches for "Roommates" with high score
 ```
 
-### Using Arithmetic Tools for Expense Calculations
+### Natural Language Expense Creation
 
 ```
-1. "Split $120 among 4 people"
-   → Uses divide(120, 4) to get 30 per person
-   → Uses create-expense with the calculated amounts
-
-2. "Calculate 15% tip on $85"
-   → Uses multiply(85, 0.15) to get tip amount
-   → Uses add(85, tip_amount) to get total
-   → Uses create-expense with the total
-
-3. "Add up expenses: $45.50, $32, $18.75"
-   → Uses add(45.50, 32) then add(result, 18.75)
-   → Uses create-expense with the total
-
-4. "What's each person's share if total is $150 and we split 60/40?"
-   → Uses multiply(150, 0.6) for first person
-   → Uses multiply(150, 0.4) for second person
-   → Uses create-expense with custom splits
+1. "I paid R25 for pizza with John and Sarah"
+   → Uses parse-sentence to extract expense details
+   → Review the preview, then set autosave=True to create
 ```
 
----
+### Managing Groups
 
 ## Best Practices
 

--- a/src/splitwise_mcp_server/client.py
+++ b/src/splitwise_mcp_server/client.py
@@ -374,6 +374,25 @@ class SplitwiseClient:
         """
         return await self.get(f"/get_user/{user_id}")
 
+    async def update_user(self, user_id: int, user_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Update a user's profile information.
+
+        Args:
+            user_id: ID of the user to update
+            user_data: Dictionary containing fields to update:
+                - first_name: New first name (optional)
+                - last_name: New last name (optional)
+                - email: New email address (optional)
+                - password: New password (optional)
+
+        Returns:
+            Dictionary containing updated user information
+
+        Raises:
+            Exception: If request fails or user not found
+        """
+        return await self.post(f"/update_user/{user_id}", data=user_data)
+
     # Expense endpoints
     
     async def get_expenses(
@@ -575,6 +594,20 @@ class SplitwiseClient:
         """
         return await self.post(f"/delete_group/{group_id}")
     
+    async def restore_group(self, group_id: int) -> Dict[str, Any]:
+        """Restore a deleted group.
+        
+        Args:
+            group_id: ID of the group to restore
+            
+        Returns:
+            Dictionary with success status
+            
+        Raises:
+            Exception: If request fails or group not found
+        """
+        return await self.post(f"/restore_group/{group_id}")
+    
     async def add_user_to_group(self, group_id: int, user_data: Dict[str, Any]) -> Dict[str, Any]:
         """Add a user to a group.
         
@@ -728,6 +761,29 @@ class SplitwiseClient:
 
     # Utility endpoints
     
+    async def parse_sentence(self, input_str: str, group_id: int = 0, friend_id: int = 0, autosave: bool = False) -> Dict[str, Any]:
+        """Parse a natural language sentence to create an expense.
+
+        Args:
+            input_str: Natural language description (e.g., "I paid $25 for pizza with John")
+            group_id: Group ID to associate expense with (optional, 0 for non-group)
+            friend_id: Friend user ID (optional, 0 for no friend)
+            autosave: Whether to auto-save the parsed expense (default: False for preview)
+
+        Returns:
+            Dictionary containing parsed expense information
+
+        Raises:
+            Exception: If request fails
+        """
+        data = {
+            "input": input_str,
+            "group_id": group_id,
+            "friend_id": friend_id,
+            "autosave": autosave,
+        }
+        return await self.post("/parse_sentence", data=data)
+
     async def get_categories(self) -> Dict[str, Any]:
         """Get all supported expense categories and subcategories.
         

--- a/src/splitwise_mcp_server/server.py
+++ b/src/splitwise_mcp_server/server.py
@@ -152,6 +152,29 @@ def register_user_tools(mcp: FastMCP) -> None:
         except Exception as e:
             logger.error(f"Error getting user {user_id}: {e}")
             raise
+    
+    @mcp.tool()
+    async def update_user(
+        user_id: int,
+        first_name: Optional[str] = None,
+        last_name: Optional[str] = None,
+        email: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Update a user's profile (first_name, last_name, email)."""
+        try:
+            user_data = {}
+            if first_name is not None:
+                user_data["first_name"] = first_name
+            if last_name is not None:
+                user_data["last_name"] = last_name
+            if email is not None:
+                user_data["email"] = email
+            result = await client.update_user(user_id, user_data)
+            logger.info(f"Updated user {user_id}")
+            return result
+        except Exception as e:
+            logger.error(f"Error updating user {user_id}: {e}")
+            raise
 
 
 # ============================================================================
@@ -506,6 +529,18 @@ def register_group_tools(mcp: FastMCP) -> None:
             raise
     
     @mcp.tool()
+    async def restore_group(group_id: int) -> Dict[str, Any]:
+        """Restore a previously deleted group."""
+        try:
+            result = await client.restore_group(group_id)
+            logger.info(f"Restored group {group_id}")
+            resolver.clear_cache()
+            return result
+        except Exception as e:
+            logger.error(f"Error restoring group {group_id}: {e}")
+            raise
+    
+    @mcp.tool()
     async def add_user_to_group(
         group_id: int,
         user_id: Optional[int] = None,
@@ -801,6 +836,26 @@ def register_notification_tools(mcp: FastMCP) -> None:
 
 def register_utility_tools(mcp: FastMCP) -> None:
     """Register utility MCP tools."""
+    
+    @mcp.tool()
+    async def parse_sentence(
+        input_str: str,
+        group_id: int = 0,
+        friend_id: int = 0,
+        autosave: bool = False,
+    ) -> Dict[str, Any]:
+        """Parse natural language into an expense (e.g. "I paid R25 for pizza with John").
+        Set autosave=True to create the expense immediately, or False to preview first."""
+        try:
+            validate_required(input_str, "input_str")
+            result = await client.parse_sentence(input_str, group_id, friend_id, autosave)
+            logger.info(f"Parsed sentence: {input_str[:50]}...")
+            return result
+        except (ValidationError, RateLimitError):
+            raise
+        except Exception as e:
+            logger.error(f"Error parsing sentence: {e}")
+            raise
     
     @mcp.tool()
     async def get_categories() -> Dict[str, Any]:


### PR DESCRIPTION
Adds three missing Splitwise API endpoints:

## `parse_sentence` — Natural language expense creation
Parse "I paid R25 for pizza with John and Sarah" directly into an expense preview or auto-saved expense.

```python
parse_sentence(
    input_str="I paid R200 for dinner with Elsje and Francois",
    group_id=100052914,
    autosave=False,
)
```

## `update_user` — Update user profile
Update first name, last name, or email for a user.

```python
update_user(user_id=518014, first_name="Adre", last_name="Greeff")
```

## `restore_group` — Restore deleted groups
Undo an accidental group deletion.

```python
restore_group(group_id=123456)
```